### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 # CTShowcase
 
 [![CI Status](http://img.shields.io/travis/scihant/CTShowcase.svg?style=flat)](https://travis-ci.org/scihant/CTShowcase)
-[![Cocoapods Compatible](https://img.shields.io/cocoapods/v/CTShowcase.svg)](https://img.shields.io/cocoapods/v/CTShowcase.svg)
+[![CocoaPods Compatible](https://img.shields.io/cocoapods/v/CTShowcase.svg)](https://img.shields.io/cocoapods/v/CTShowcase.svg)
 [![Issues](https://img.shields.io/github/issues/scihant/CTShowcase.svg?style=flat)](http://www.github.com/scihant/CTShowcase/issues?state=open)
 
 CTShowcase is a showcase library for iOS that lets you to highlight individual views in your app using static or dynamic effects.


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
